### PR TITLE
Corrección de errores

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+vx-utils (1.5-1) unstable; urgency=low
+
+  * Se corrige la función get_user_info para que funcione con el ID del usuario,
+    además del nombre (por si contiene más de 8 caracteres).
+  * Se modifica el script vx-user-get-mozilla-profile para evitar el error que
+    el usuario no exista a la hora de buscar la información del perfil.
+
+ -- Jose Antonio Chavarría <jachavar@gmail.com>  Wed, 9 Nov 2016 07:59:13 +0100
+
 vx-utils (1.4-1) unstable; urgency=low
 
   * Se incluye la licencia en los ficheros donde faltaba.

--- a/usr/bin/vx-user-get-mozilla-profile
+++ b/usr/bin/vx-user-get-mozilla-profile
@@ -89,7 +89,13 @@ def run():
     else:
         app_path = '.thunderbird'
 
-    home = vx.get_user_info(args['user'])['home']
+    user_info = vx.get_user_info(args['user'])
+    if not user_info:
+        if not args['quiet']:
+            print('User {}, not exists!!!'.format(args['user']))
+        sys.exit(errno.EACCES)
+
+    home = user_info['home']
     ini_file = os.path.join(home, app_path, 'profiles.ini')
 
     if not os.path.exists(ini_file):

--- a/usr/share/pyshared/vx_lib.py
+++ b/usr/share/pyshared/vx_lib.py
@@ -302,19 +302,22 @@ def get_user_info(user):
     """
 
     try:
-        info = pwd.getpwnam(user)
-
-        return {
-            'name': info[0],
-            'pwd': info[1],  # if 'x', encrypted
-            'uid': info[2],
-            'gid': info[3],
-            'fullname': info[4],
-            'home': info[5],
-            'shell': info[6]
-        }
+        _info = pwd.getpwnam(user)
     except KeyError:
-        return False
+        try:
+            _info = pwd.getpwuid(int(user))
+        except:
+            return False
+
+    return {
+        'name': _info[0],
+        'pwd': _info[1],  # if 'x', encrypted
+        'uid': _info[2],
+        'gid': _info[3],
+        'fullname': _info[4],
+        'home': _info[5],
+        'shell': _info[6]
+    }
 
 
 def user_is_root(user):


### PR DESCRIPTION
Información de usuario adecuada si se pasa el UID en lugar del nombre.

Comprobación de la existencia de usuario en vx-user-get-mozilla-profile.