### PR TITLE
get_net_device_info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+vx-utils (1.10-1) unstable; urgency=low
+
+  * Se corrige la función get_net_device_info para el caso en que el interfaz
+    de red no tenga IP asignada.
+
+ -- Jose Antonio Chavarría <jachavar@gmail.com>  Wed, 14 Apr 2021 09:24:41 +0200
+
 vx-utils (1.9-1) unstable; urgency=low
 
   * Cambios para adecuarse al final de Python2 y trabajar sólo con Python3

--- a/usr/lib/python3/dist-packages/vx_lib.py
+++ b/usr/lib/python3/dist-packages/vx_lib.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 
-# Copyright (c) 2011-2020 Jose Antonio Chavarría <jachavar@gmail.com>
+# Copyright (c) 2011-2021 Jose Antonio Chavarría <jachavar@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -185,10 +185,13 @@ def get_net_device_info():
             tmp = output.split('\n')
             mac = tmp[1].strip().split(' ')[1]
 
+            ip = ''
+            mask = 0
             output = subprocess.getoutput(cmd_ip.format(iface))
-            tmp = output.split('\n')
-            data = tmp[0].strip().split(' ')[1]
-            ip, mask = data.split('/')
+            if output:
+                tmp = output.split('\n')
+                data = tmp[0].strip().split(' ')[1]
+                ip, mask = data.split('/')
 
             devices[iface] = {
                 'ip': ip,


### PR DESCRIPTION
Se corrige la función get_net_device_info para el caso en que el interfaz de red no tenga IP asignada